### PR TITLE
fix: redundant async await

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -31,7 +31,7 @@
     },
     "..": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "0.0.5",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "canonicalize": "^2.0.0",

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useEffect } from 'react'
 
-import type { ReclaimVerficationRequest } from '@reclaimprotocol/js-sdk'
+import type { ReclaimVerificationRequest } from '@reclaimprotocol/js-sdk'
 import { ReclaimClient } from '@reclaimprotocol/js-sdk'
 
 import { useQRCode } from 'next-qrcode'
@@ -10,7 +10,7 @@ import Link from 'next/link'
 
 export default function Home() {
   const [verificationReq, setVerificationReq] = React.useState<
-     ReclaimVerficationRequest | undefined
+     ReclaimVerificationRequest | undefined
   >()
   const [extracted, setExtracted] = React.useState<any>(null)
   const { Canvas } = useQRCode()
@@ -24,9 +24,9 @@ export default function Home() {
 
     const providerV2 = await reclaimClient.buildHttpProviderV2ByID(providers)
 
-    const requestProofs = await reclaimClient.buildRequestedProofs(
+    const requestProofs = reclaimClient.buildRequestedProofs(
       providerV2,
-      await reclaimClient.getAppCallbackUrl()
+      reclaimClient.getAppCallbackUrl()
     )
 
     reclaimClient.setSignature(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "canonicalize": "^2.0.0",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -29,7 +29,7 @@ export class ReclaimClient {
     sessionId: string = ''
     requestedProofs?: RequestedProofs
     context: Context = { contextAddress: '0x0', contextMessage: '' }
-    verificationRequest?: ReclaimVerficationRequest
+    verificationRequest?: ReclaimVerificationRequest
 
     constructor(applicationId: string, sessionId?: string) {
         this.applicationId = applicationId
@@ -42,7 +42,7 @@ export class ReclaimClient {
 
     async createVerificationRequest(providers: string[]) {
         const template = await this.createLinkRequest(providers)
-        this.verificationRequest = new ReclaimVerficationRequest(
+        this.verificationRequest = new ReclaimVerificationRequest(
             this.sessionId,
             this.getStatusUrl(),
             template
@@ -93,7 +93,7 @@ export class ReclaimClient {
         this.appCallbackUrl = url
     }
 
-    async getAppCallbackUrl() {
+    getAppCallbackUrl() {
         let appCallbackUrl = this.appCallbackUrl
         if (!appCallbackUrl) {
             appCallbackUrl = `${DEFAULT_RECLAIM_CALLBACK_URL}${this.sessionId}`
@@ -139,6 +139,8 @@ export class ReclaimClient {
     ): Promise<ProviderV2[]> {
         try {
 
+            if(providerIds.length === 0) throw new Error('No provider Ids provided. Please pass at least one provider Id. Check https://dev.reclaimprotocol.org/applications for more details.')
+            
             const appProvidersUrl = `https://api.reclaimprotocol.org/v2/app-http-providers/${this.applicationId}`
             const appResponse = await fetch(appProvidersUrl)
 
@@ -152,7 +154,7 @@ export class ReclaimClient {
             } catch (e) {
                 throw new Error('APP_ID is not valid! Please try again once more.')
             }
-            const requiredProviders: ProviderV2[] = []
+
             for (let i = 0; i < providerIds.length; i++) {
                 const providerToAdd = appProviders.find(provider => provider.httpProviderId === providerIds[i])
                 if (!providerToAdd) {
@@ -264,7 +266,7 @@ export class ReclaimClient {
     }
 }
 
-export class ReclaimVerficationRequest {
+export class ReclaimVerificationRequest {
     onSuccessCallback?: (data: Proof | Error | unknown) => void | unknown
     onFailureCallback?: (data: Proof | Error | unknown) => void | unknown
     sessionId: string


### PR DESCRIPTION
This PR fixes:

- Typo in ReclaimVerificationRequest
- Check for empty providers list
- Remove unnecessary use of async keyword used for functions that do not have await expressions